### PR TITLE
Add support for custom docker-compose.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,6 @@
 !/.devcontainer/devcontainer.example.json
 !/.devcontainer/docker-compose.extend-example.yml
 
+docker-compose.custom.yml
+
 .DS_Store


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR addes support for an untracked `docker-compose.custom.yml` file under `laradock` directory.

## Motivation and Context
<!--- What problem does it solve, or what feature does it add? -->
For some reason, one may want/need to edit laradock's default file `docker-compose.yml` e.g. srtipping out uneeded services, so that the whole project can be brought up with a simple `docker-compose up` command. With this PR, the user can copy default `docker-compose.yml` as `docker-compose.custom.yml` and make the desired changes there. This file will not be tracked by Git, so it won't interfere with an eventual laradock submodule versioning within a project.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [ ] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
